### PR TITLE
chore: update golang version to 1.21.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19
+golang 1.21.1

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@
     ### `go mod tidy`
 - Please make sure you set proper database configuration to connect.
 ---
+### Add Storage Drivers
+- Ref : [gofiber storage](https://docs.gofiber.io/storage/)
+
+---
 ### **Multiple Database System Support**
 
 - We are supporting 3 types of database at this time `postgres`, `mysql` & `sqlite3`


### PR DESCRIPTION
### Updates

- Update tool-version guide for the asdf, as it was throwing error of tool-version in 1.19 golang version.